### PR TITLE
Fix installation errors due to the lack of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "cordova-plugin-motion-activity",
+  "version": "0.0.1",
+  "description": "A Cordova plugin that detects and watch motion API",
+  "cordova": {
+    "id": "cordova-plugin-motion-activity",
+    "platforms": [
+      "ios"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mrameezraja/cordova-plugin-motion-activity.git"
+  },
+  "keywords": [
+    "cordova",
+    "motion activity detection",
+    "ecosystem:cordova",
+    "cordova-ios"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.0.0"
+    }
+  ],
+  "author": "Rameez Raja",
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/mrameezraja/cordova-plugin-motion-activity/issues"
+  },
+  "homepage": "https://github.com/mrameezraja/cordova-plugin-motion-activity#readme"
+}


### PR DESCRIPTION
# Other developers can install your plugin automatically using either plugman or the Cordova CLI.

When someone tries to add the plugin in recent versions of cordova with the following command:

`cordova plugin add https://github.com/mrameezraja/cordova-plugin-motion-activity.git`

The following error arise 

```
Failed to fetch plugin https://github.com/mrameezraja/cordova-plugin-motion-activity.git via registry.
Probably this is either a connection problem, or plugin spec is incorrect.
````

Adding the package.json as the cordova documentation reflect will avoid to clone locally the project and create the package.json, and add the plugin locally as it will be a developed plugin.

see: https://cordova.apache.org/docs/en/latest/guide/hybrid/plugins/index.html#publishing-plugins